### PR TITLE
Allow optional to be false

### DIFF
--- a/anavar_utils.py
+++ b/anavar_utils.py
@@ -32,14 +32,23 @@ class Snp1ControlFile(object):
 
         if len(sfs_not_given) > 0:
             raise KeyError('Missing the following SFS in input: {}'.format(','.join(sfs_not_given)))
-
-    def set_alg_opts(self, alg='NLOPT_LD_LBFGS', search=500, optional=True):
+            
+  def set_alg_opts(self, alg='NLOPT_LD_LBFGS', maxeval=100000, maxtime=600, search=500, nnoimp=1, maximp=3,
+                     optional=True, size=10000, key=3, epsabs=1e-50, epsrel=1e-10, rftol=1e-10):
 
         """
         sets algorithm options in control file
         :param alg: str
+        :param maxeval: int
+        :param maxtime: int
         :param search: int
+        :param nnoimp: int
         :param optional: bool
+        :param: size: int
+        :param: key: int
+        :param epsabs: float
+        :param epsrel: float
+        :param rftol: float
         :return: sets algorithm string
         """
 
@@ -50,20 +59,20 @@ class Snp1ControlFile(object):
 
         alg_string = ('[algorithm_commands]\n'
                       'search_algorithm: {}\n'
-                      'maxeval: 100000\n'
-                      'maxtime: 600\n'
+                      'maxeval: {}\n'
+                      'maxtime: {}\n'
                       'num_searches: {}\n'
-                      'nnoimp: 1\n'
-                      'maximp: 3\n').format(alg, search)
+                      'nnoimp: {}\n'
+                      'maximp: {}\n').format(alg, maxeval, maxtime, search, nnoimp, maximp)
 
         if optional:
             alg_string += ('optional: true\n'
-                           'size: 10000\n'
-                           'key: 3\n'
-                           'epsabs: 1e-20\n'
-                           'epsrel: 1e-9\n'
-                           'rftol: 1e-9\n'
-                           '\n')
+                           'size: {}\n'
+                           'key: {}\n'
+                           'epsabs: {}\n'
+                           'epsrel: {}\n'
+                           'rftol: {}\n'
+                           '\n').format(size, key, epsabs, epsrel, rftol)
         else:
             alg_string += 'optional: false\n\n'
 

--- a/anavar_utils.py
+++ b/anavar_utils.py
@@ -33,12 +33,13 @@ class Snp1ControlFile(object):
         if len(sfs_not_given) > 0:
             raise KeyError('Missing the following SFS in input: {}'.format(','.join(sfs_not_given)))
 
-    def set_alg_opts(self, alg='NLOPT_LD_LBFGS', search=500):
+    def set_alg_opts(self, alg='NLOPT_LD_LBFGS', search=500, optional=True):
 
         """
         sets algorithm options in control file
         :param alg: str
         :param search: int
+        :param optional: bool
         :return: sets algorithm string
         """
 
@@ -53,17 +54,21 @@ class Snp1ControlFile(object):
                       'maxtime: 600\n'
                       'num_searches: {}\n'
                       'nnoimp: 1\n'
-                      'maximp: 3\n'
-                      'optional: true\n'
-                      'size: 10000\n'
-                      'key: 3\n'
-                      'epsabs: 1e-20\n'
-                      'epsrel: 1e-9\n'
-                      'rftol: 1e-9\n'
-                      '\n').format(alg, search)
+                      'maximp: 3\n').format(alg, search)
+
+        if optional:
+            alg_string += ('optional: true\n'
+                           'size: 10000\n'
+                           'key: 3\n'
+                           'epsabs: 1e-20\n'
+                           'epsrel: 1e-9\n'
+                           'rftol: 1e-9\n'
+                           '\n')
+        else:
+            alg_string += 'optional: false\n\n'
 
         self.alg_opts = alg_string
-
+        
     def set_data(self, sfs_m, n, snp_fold=False,
                  dfe='discrete', c=1,
                  theta_r=(1e-6, 0.1), gamma_r=(-250, 10), error_r=(0.0, 0.5),

--- a/anavar_utils.py
+++ b/anavar_utils.py
@@ -34,7 +34,7 @@ class Snp1ControlFile(object):
             raise KeyError('Missing the following SFS in input: {}'.format(','.join(sfs_not_given)))
             
   def set_alg_opts(self, alg='NLOPT_LD_LBFGS', maxeval=100000, maxtime=600, search=500, nnoimp=1, maximp=3,
-                     optional=True, size=10000, key=3, epsabs=1e-50, epsrel=1e-10, rftol=1e-10):
+                     optional=False, size=10000, key=3, epsabs=1e-50, epsrel=1e-10, rftol=1e-10):
 
         """
         sets algorithm options in control file


### PR DESCRIPTION
Allow 'optional: false' for the algorithm commands. If optional is set to false, it does not write the optional commands that come after, as they are not needed.